### PR TITLE
Suppress "Program stopped working" message

### DIFF
--- a/PokemonGo.RocketAPI.Console/Program.cs
+++ b/PokemonGo.RocketAPI.Console/Program.cs
@@ -15,6 +15,14 @@ namespace PokemonGo.RocketAPI.Console
 
         private static void Main(string[] args)
         {
+            AppDomain.CurrentDomain.UnhandledException
+                += delegate (object sender, UnhandledExceptionEventArgs eargs)
+                {
+                    Exception exception = (Exception)eargs.ExceptionObject;
+                    System.Console.WriteLine("Unhandled exception: " + exception);
+                    Environment.Exit(1);
+                };
+                
             Logger.SetLogger(new Logging.ConsoleLogger(LogLevel.Info));
 
             Task.Run(() =>


### PR DESCRIPTION
Suppress the "Program stopped working" dialog so that the bot can run from a bash script w/o having to dismiss this message when it crashes.

Taken from here:
http://stackoverflow.com/questions/1421597/avoid-program-stopped-working-in-c-net