### PR TITLE
Fixed PokemonsToEvolve.txt Minor Typo #18

### DIFF
--- a/PokemonGo.RocketAPI.Console/Resources/PokemonsToEvolve.txt
+++ b/PokemonGo.RocketAPI.Console/Resources/PokemonsToEvolve.txt
@@ -4,7 +4,7 @@ Spearow
 Ekans
 Pikachu
 Sandshrew
-Clefable
+Clefairy
 Vulpix
 Jigglypuff
 Zubat


### PR DESCRIPTION
Clefairy instead of Clefable.